### PR TITLE
Parallelize crawling through courses

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -107,15 +107,11 @@ async fn main() -> Result<()> {
             break;
         }
     }
-    // Sanity check: since there are no running tasks, main() should be the only reference
-    let options = Arc::try_unwrap(options).unwrap_or_else(|e| {
-        panic!("Please report on GitHub. Main should be sole reference, err={e:?}")
-    });
     println!();
 
     // Tokio uses the number of cpus as num of work threads in the default runtime
     let num_worker_threads = num_cpus::get();
-    let files_to_download = Arc::new(options.files_to_download.into_inner());
+    let files_to_download = Arc::new(options.files_to_download.lock().await.clone());
     let num_worker_extra_work = files_to_download.len() % num_worker_threads;
     let min_work = files_to_download.len() / num_worker_threads;
     let progress_bars = Arc::new(MultiProgress::new());


### PR DESCRIPTION
Wow why are we using `atomic`s?

Problem: sequentially crawling all courses takes >10s (for me, with 8 courses)
Solution: parallelize requests

Problem: canvas rate limits requests
Solution: use a semaphore set at nCPU (_open for discussion_)

Problem: `main()` should continue only AFTER all files crawled, but there are unknown number of files/sub-folders
Solution: roll our own barrier with `AtomicUsize`, but make sure it drops to 0 only when all tasks are done (proof is in the comments)

Problem: recursive `async` functions are not supported in rust (because compiler can't generate state machine at compile time for cyclic-looking functions, because nStates must be bounded)
Solution: call `tokio::spawn` in a non-`async` function so that it is not part of the state machine. Conveniently, we can decouple our barrier logic from the processing function

What do you get from this PR?
From a sample size of n=1, runtime decreased from 9.301s to 1.463s! Now that's _blazingly fast_.

Thank you for reading. Have fun reviewing the code!