### PR TITLE
Handle pagination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,6 +78,7 @@ dependencies = [
  "futures",
  "indicatif",
  "num_cpus",
+ "parse_link_header",
  "reqwest",
  "sanitize-filename",
  "serde",
@@ -801,6 +811,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse_link_header"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3687fe9debbbf2a019f381a8bc6b42049b22647449b39af54b3013985c0cf6de"
+dependencies = [
+ "http",
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -896,6 +917,8 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ filetime = "0.2"
 futures = "0.3"
 indicatif = "0.17"
 num_cpus = "1"
+parse_link_header = "0.3.3"
 reqwest = { version = "0.11", features = ["json"] }
 sanitize-filename = "0.4"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
Canvas API returns 10 files/folders/courses every request, resulting in missing downloads.

We fix this by parsing LINK header to crawl all pages, in accordance with https://canvas.instructure.com/doc/api/file.pagination.html.

Closes #10