### PR TITLE
Parallelize courses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ tokio = { version = ">=1", features = ["full"] }
 
 [profile.release]
 strip = true
+panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "canvas-downloader"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
The current performance bottleneck is sequentially getting the list of files for all courses, which takes 10s for me.

This PR tackles the bottleneck and a few other goals:
- Don't flood canvas server with requests.
We "solve" this using a semaphore on concurrent requests [1].
- Currently, we get the list of files before downloading them [2].
This requires a barrier to halt `main()`. The barrier must also increase as files/folders are discovered for crawling, which is not supported by `tokio::sync::Barrier`.
We solve this by rolling our own `AtomicUsize` counter.
- Reduce code duplication by writing `fork()` wrapper for recursive `async` functions such as `process_folders` and `process_files`.
Because recursive `async` functions are unsupported, we sidestep this with a macro that creates a non-`async` function and calls `tokio::spawn`.
  
Results
From a sample size of n=1, runtime decreased from 9.301s to 1.463s! Now that's _blazingly fast_.

Closes #19. **Don't merge** until I have conducted more tests.

[1]: Even with semaphores, we can still exceed QPS if canvas responds instantly. For example, if we send 8 concurrent requests and canvas responds to all in 1ms, we can send 8000 queries in 1 second. A better solution can be discussed in #17 
[2]: I presume for display purposes. We can actually pipeline the entire process.