### PR TITLE
Add atomic download

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
 name = "atty"
@@ -69,7 +69,7 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "canvas-downloader"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -101,9 +101,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -116,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.6"
+version = "4.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0b0588d44d4d63a87dbd75c136c166bbfd9a86a31cb89e09906521c7d3f5e3"
+checksum = "3c911b090850d79fc64fe9ea01e28e465f65e821e08813ced95bced72f7a8a9b"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -131,22 +131,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.1.0"
+version = "4.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
+checksum = "9a932373bab67b984c790ddf2c9ca295d8e3af3b7ef92de5a5bacdccdee4b09b"
 dependencies = [
  "heck",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.10",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
+checksum = "033f6b7a4acb1f358c742aaca805c939ee73b4c6209ae4318ec7aca81c42e646"
 dependencies = [
  "os_str_bytes",
 ]
@@ -192,9 +191,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cxx"
-version = "1.0.91"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d3488e7665a7a483b57e25bdd90d0aeb2bc7608c8d0346acf2ad3f1caf1d62"
+checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -204,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.91"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fcaf066a053a41a81dfb14d57d99738b767febb8b735c3016e469fac5da690"
+checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -214,24 +213,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 2.0.10",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.91"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ef98b8b717a829ca5603af80e1f9e2e48013ab227b68ef37872ef84ee479bf"
+checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.91"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "086c685979a698443656e5cf7856c95c642295a38599f12fb1ff76fb28d19892"
+checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -323,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
+checksum = "531ac96c6ff5fd7c62263c5e3c67a603af4fcaee2e1a0ae5565ba3a11e69e549"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -338,9 +337,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
+checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -348,15 +347,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
+checksum = "1997dd9df74cdac935c76252744c1ed5794fac083242ea4fe77ef3ed60ba0f83"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -365,38 +364,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
+checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
+checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
+checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
 
 [[package]]
 name = "futures-task"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
+checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
 
 [[package]]
 name = "futures-util"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
+checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -412,9 +411,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
+checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
 dependencies = [
  "bytes",
  "fnv",
@@ -501,9 +500,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.24"
+version = "0.14.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e011372fa0b68db8350aa7a248930ecc7839bf46d8485577d69f117a75f164c"
+checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -538,16 +537,16 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.53"
+version = "0.1.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+checksum = "0c17cc76786e99f8d2f055c11159e7f0091c42474dcc3189fbab96072e873e6d"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "winapi 0.3.9",
+ "windows",
 ]
 
 [[package]]
@@ -572,9 +571,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -603,10 +602,11 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
+checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
 dependencies = [
+ "hermit-abi 0.3.1",
  "libc",
  "windows-sys 0.45.0",
 ]
@@ -619,9 +619,9 @@ checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
+checksum = "8687c819457e979cc940d09cb16e42a1bf70aa6b60a549de6d3a62a0ee90c69e"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
@@ -631,9 +631,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "js-sys"
@@ -662,9 +662,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "link-cplusplus"
@@ -708,9 +708,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "mime"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
@@ -791,9 +791,9 @@ checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "openssl"
-version = "0.10.45"
+version = "0.10.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
+checksum = "518915b97df115dd36109bfa429a48b8f737bd05508cf9588977b599648926d2"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -812,7 +812,7 @@ checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -823,9 +823,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.80"
+version = "0.9.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
+checksum = "666416d899cf077260dac8698d60a60b435a46d57e82acb1be3d0dad87284e5b"
 dependencies = [
  "autocfg",
  "cc",
@@ -836,9 +836,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.4.1"
+version = "6.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
 name = "parking_lot"
@@ -905,43 +905,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26f6a7b87c2e435a3241addceeeff740ff8b7e76b74c13bf9acb17fa454ea00b"
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -966,9 +942,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.1"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -977,24 +953,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi 0.3.9",
-]
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "reqwest"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
+checksum = "0ba30cc2c0cd02af1222ed216ba659cdb2f879dfe3181852fe7c50b1d0005949"
 dependencies = [
  "base64",
  "bytes",
@@ -1029,9 +996,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.8"
+version = "0.36.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
+checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
 dependencies = [
  "bitflags",
  "errno",
@@ -1043,9 +1010,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "sanitize-filename"
@@ -1074,9 +1041,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scratch"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
+checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
 
 [[package]]
 name = "security-framework"
@@ -1103,29 +1070,29 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.10",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
+checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
 dependencies = [
  "itoa",
  "ryu",
@@ -1170,9 +1137,9 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "socket2"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -1186,9 +1153,20 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aad1363ed6d37b84299588d62d3a7d95b5a5c2d9aad5c85609fda12afaa1f40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1197,16 +1175,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
 dependencies = [
  "cfg-if",
  "fastrand",
- "libc",
  "redox_syscall",
- "remove_dir_all",
- "winapi 0.3.9",
+ "rustix",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1271,9 +1248,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.25.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
+checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1286,7 +1263,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1297,7 +1274,7 @@ checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1358,15 +1335,15 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.10"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-normalization"
@@ -1399,12 +1376,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "want"
@@ -1449,7 +1420,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
 
@@ -1483,7 +1454,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1548,6 +1519,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdacb41e6a96a052c6cb63a144f24900236121c6f63f4f8219fef5977ecb0c25"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1573,9 +1553,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -1588,45 +1568,45 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,3 @@ tokio = { version = ">=1", features = ["full"] }
 
 [profile.release]
 strip = true
-panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "canvas-downloader"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use std::{
     },
 };
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Error, Result};
 use chrono::DateTime;
 use clap::Parser;
 use futures::future::ready;
@@ -37,21 +37,24 @@ struct CommandLineOptions {
 macro_rules! fork {
     // Motivation: recursive async functions are unsupported. We avoid this by using a non-async
     // function `f` to tokio::spawn our recursive function. Conveniently, we can wrap our barrier logic in this function
-    ($f:expr, $url:expr, $path:expr, $options:expr) => {{
-        fn f(url: String, path: PathBuf, options: Arc<ProcessOptions>) {
+    ($f:expr, $arg:expr, $T:ty, $options:expr) => {{
+        fn g(arg: $T, options: Arc<ProcessOptions>) {
             options.n_active_requests.fetch_add(1, Ordering::AcqRel);
             tokio::spawn(async move {
                 let _sem = options.sem_requests.acquire().await.unwrap_or_else(|e| {
                     panic!("Please report on GitHub. Unexpected closed sem, err={e}")
                 });
-                $f(url, path, options.clone()).await;
+                let res = $f(arg, options.clone()).await;
                 let new_val = options.n_active_requests.fetch_sub(1, Ordering::AcqRel) - 1;
                 if new_val == 0 {
                     options.notify_main.notify_one();
                 }
+                if let Err(e) = res {
+                    eprintln!("{e:#?}");
+                }
             });
         }
-        f($url, $path, $options);
+        g($arg, $options);
     }};
 }
 
@@ -73,25 +76,40 @@ async fn main() -> Result<()> {
 
     // Prepare GET request options
     let client = reqwest::ClientBuilder::new()
+        .tcp_keepalive(Some(Duration::from_secs(10)))
         .http2_keep_alive_interval(Some(Duration::from_secs(2)))
-        .timeout(Duration::from_secs(10))
         .build()
         .with_context(|| "Failed to create HTTP client")?;
     let courses_link = format!("{}/api/v1/users/self/favorites/courses", cred.canvas_url);
     let options = Arc::new(ProcessOptions {
         canvas_token: cred.canvas_token.clone(),
         client: client.clone(),
+        // Process
         files_to_download: tokio::sync::Mutex::new(Vec::new()),
         download_newer: args.download_newer,
+        // Download
+        progress_bars: MultiProgress::new(),
+        progress_style: {
+            let style_template = if termsize::get().map_or(false, |size| size.cols < 100) {
+                "[{wide_bar:.cyan/blue}] {total_bytes} - {msg}"
+            } else {
+                "[{bar:20.cyan/blue}] {bytes}/{total_bytes} - {bytes_per_sec} - {msg}"
+            };
+            ProgressStyle::default_bar()
+                .template(style_template)
+                .unwrap_or_else(|e| panic!("Please report this issue on GitHub: error with progress bar style={style_template}, err={e}"))
+                .progress_chars("=>-")
+        },
+        // Synchronization
         n_active_requests: AtomicUsize::new(0),
         sem_requests: tokio::sync::Semaphore::new(8), // WARN magic constant.
-        // TODO handle canvas rate limiting errors, maybe scale up if possible
         notify_main: tokio::sync::Notify::new(),
+        // TODO handle canvas rate limiting errors, maybe scale up if possible
     });
 
     // Get courses
     let courses: Vec<canvas::Course> = get_pages(courses_link.clone(), &options)
-        .await
+        .await?
         .into_iter()
         .map(|resp| resp.json::<Vec<serde_json::Value>>()) // resp --> Result<Vec<json>>
         .collect::<stream::FuturesUnordered<_>>() // (in any order)
@@ -147,8 +165,8 @@ async fn main() -> Result<()> {
 
         fork!(
             process_folders,
-            course_folders_link,
-            course_folder_path,
+            (course_folders_link, course_folder_path),
+            (String, PathBuf),
             options.clone()
         );
     }
@@ -163,18 +181,10 @@ async fn main() -> Result<()> {
     // 3. Bounded concurrency: acquire or block on semaphore before request
     // 4. No busy wait: Last task will see that there are 0 active requests and notify main
     options.notify_main.notified().await;
-    // Sanity check: running tasks trying to acquire sem will panic
-    options.sem_requests.close();
     assert_eq!(options.n_active_requests.load(Ordering::Acquire), 0);
     println!();
 
-    // Tokio uses the number of cpus as num of work threads in the default runtime
-    let num_worker_threads = num_cpus::get();
-    let files_to_download = Arc::new(options.files_to_download.lock().await.clone());
-    let num_worker_extra_work = files_to_download.len() % num_worker_threads;
-    let min_work = files_to_download.len() / num_worker_threads;
-    let progress_bars = Arc::new(MultiProgress::new());
-
+    let files_to_download = options.files_to_download.lock().await;
     println!(
         "Downloading {} file{}",
         files_to_download.len(),
@@ -185,141 +195,27 @@ async fn main() -> Result<()> {
         }
     );
 
-    let mut join_handles = Vec::new();
-    let atomic_file_index = Arc::new(AtomicUsize::new(0));
-
-    // We manually limit each worker thread to only deal with 1 file at all time to avoid
-    // spamming http requests
-    for i in 0..num_worker_threads {
-        let mut work = min_work;
-        if i < num_worker_extra_work {
-            work += 1;
-        }
-        let canvas_token = cred.canvas_token.clone();
-        let client = client.clone();
-        let files_to_download = files_to_download.clone();
-        let progress_bars = progress_bars.clone();
-        let atomic_file_index = atomic_file_index.clone();
-        let handle = tokio::spawn(async move {
-            for _ in 0..work {
-                let file_index = atomic_file_index.fetch_add(1, Ordering::AcqRel);
-                let canvas_file = files_to_download.get(file_index).expect(
-                    "Please report this issue on GitHub: downloading file with index out of bounds",
-                );
-
-                // We need to determine the file size before we download, so we can create a ProgressBar
-                // A Header request for the CONTENT_LENGTH header gets us the file size
-                let download_size = {
-                    let resp = client
-                        .head(&canvas_file.url)
-                        .send()
-                        .await
-                        .unwrap_or_else(|e| {
-                            panic!(
-                                "Unable to get file information for {:?}, err={e}",
-                                canvas_file
-                            )
-                        });
-                    if resp.status().is_success() {
-                        resp.headers() // Gives us the HeaderMap
-                            .get(header::CONTENT_LENGTH) // Gives us an Option containing the HeaderValue
-                            .and_then(|ct_len| ct_len.to_str().ok()) // Unwraps the Option as &str
-                            .and_then(|ct_len| ct_len.parse().ok()) // Parses the Option as u64
-                            .unwrap_or(0) // Fallback to 0
-                    } else {
-                        // We return an Error if something goes wrong here
-                        println!("Failed to download {}", canvas_file.display_name);
-                        continue;
-                    }
-                };
-
-                let progress_bar = progress_bars.add(ProgressBar::new(download_size));
-
-                let style_template = if termsize::get().map_or(false, |size| size.cols < 100) {
-                    "[{wide_bar:.cyan/blue}] {total_bytes} - {msg}"
-                } else {
-                    "[{bar:20.cyan/blue}] {bytes}/{total_bytes} - {bytes_per_sec} - {msg}"
-                };
-                progress_bar.set_style(
-                    ProgressStyle::default_bar()
-                        .template(style_template)
-                        .unwrap_or_else(|e| panic!("Please report this issue on GitHub: error with progress bar style={style_template}, err={e}"))
-                        .progress_chars("=>-"),
-                );
-
-                let message = canvas_file.display_name.to_string();
-
-                progress_bar.set_message(message);
-
-                let mut file = std::fs::File::create(&canvas_file.filepath).unwrap_or_else(|e| {
-                    panic!(
-                        "Unable to create file={:?} with err={e}",
-                        canvas_file.filepath
-                    )
-                });
-                // canvas also provides a modified_time of the file but updated_at should be more proper
-                // as it probably represents the upload date of the file which is more apt for determining
-                // if the file was changed since downloading it
-                match DateTime::parse_from_rfc3339(&canvas_file.updated_at) {
-                    Ok(updated_at) => {
-                        if filetime::set_file_mtime(
-                            &canvas_file.filepath,
-                            filetime::FileTime::from_unix_time(
-                                updated_at.timestamp(),
-                                updated_at.timestamp_subsec_nanos(),
-                            ),
-                        )
-                        .is_err()
-                        {
-                            println!(
-                                "Failed to set modified time of {} with updated_at of {}",
-                                canvas_file.display_name, canvas_file.updated_at
-                            );
-                        };
-                    }
-                    Err(_) => {
-                        println!(
-                            "Failed to parse updated_at time for {}, {}",
-                            canvas_file.display_name, canvas_file.updated_at
-                        );
-                        continue;
-                    }
-                };
-
-                let mut file_response = client
-                    .get(&canvas_file.url)
-                    .bearer_auth(&canvas_token)
-                    .send()
-                    .await
-                    .unwrap_or_else(|e| {
-                        panic!(
-                            "Something went wrong when reaching {}, err={e}",
-                            canvas_file.url
-                        )
-                    });
-
-                while let Some(chunk) = file_response.chunk().await.unwrap_or_else(|e| {
-                    panic!(
-                        "Something went wrong downloading {}, err={e}",
-                        canvas_file.url
-                    )
-                }) {
-                    progress_bar.inc(chunk.len() as u64);
-                    let mut cursor = std::io::Cursor::new(chunk);
-                    std::io::copy(&mut cursor, &mut file).unwrap_or_else(|e| {
-                        panic!("Could not save file {:?}, err={e}", canvas_file.filepath)
-                    });
-                }
-                progress_bar.finish();
-            }
-        });
-
-        join_handles.push(handle);
+    // Download files
+    options.n_active_requests.fetch_add(1, Ordering::AcqRel); // prevent notifying until all spawned
+    for canvas_file in files_to_download.iter() {
+        fork!(
+            download_or_delete_file,
+            canvas_file.clone(),
+            File,
+            options.clone()
+        );
     }
 
-    for handle in join_handles {
-        handle.await?;
+    // Wait for downloads
+    let new_val = options.n_active_requests.fetch_sub(1, Ordering::AcqRel) - 1;
+    if new_val == 0 {
+        // notify if all finished immediately
+        options.notify_main.notify_one();
     }
+    options.notify_main.notified().await;
+    // Sanity check: running tasks trying to acquire sem will panic
+    options.sem_requests.close();
+    assert_eq!(options.n_active_requests.load(Ordering::Acquire), 0);
 
     for canvas_file in files_to_download.iter() {
         println!(
@@ -329,6 +225,73 @@ async fn main() -> Result<()> {
         );
     }
 
+    Ok(())
+}
+
+async fn download_or_delete_file(file: File, options: Arc<ProcessOptions>) -> Result<()> {
+    download_file(file.clone(), options.clone())
+        .await
+        .with_context(|| {
+            format!(
+                "Error downloading file. Deleting: {:#?}",
+                std::fs::remove_file(&file.filepath)
+            )
+        })
+}
+
+async fn download_file(canvas_file: File, options: Arc<ProcessOptions>) -> Result<()> {
+    // Get file
+    let mut resp = options
+        .client
+        .head(&canvas_file.url)
+        .bearer_auth(&options.canvas_token)
+        .send()
+        .await
+        .with_context(|| format!("Something went wrong when reaching {}", canvas_file.url))?;
+    if !resp.status().is_success() {
+        return Err(Error::msg(format!(
+            "Failed to download {}, got {resp:#?}",
+            canvas_file.display_name
+        )));
+    }
+
+    // Create + Open file
+    let mut file = std::fs::File::create(&canvas_file.filepath)
+        .with_context(|| format!("Unable to create file={:?}", canvas_file.filepath))?;
+
+    // Update file time
+    let updated_at = DateTime::parse_from_rfc3339(&canvas_file.updated_at)?;
+    let updated_time = filetime::FileTime::from_unix_time(
+        updated_at.timestamp(),
+        updated_at.timestamp_subsec_nanos(),
+    );
+    filetime::set_file_mtime(&canvas_file.filepath, updated_time).with_context(|| {
+        format!(
+            "Failed to set modified time of {} with updated_at of {}",
+            canvas_file.display_name, canvas_file.updated_at
+        )
+    })?;
+
+    // Progress bar
+    let download_size = resp
+        .headers() // Gives us the HeaderMap
+        .get(header::CONTENT_LENGTH) // Gives us an Option containing the HeaderValue
+        .and_then(|ct_len| ct_len.to_str().ok()) // Unwraps the Option as &str
+        .and_then(|ct_len| ct_len.parse().ok()) // Parses the Option as u64
+        .unwrap_or(0); // Fallback to 0
+    let progress_bar = options.progress_bars.add(ProgressBar::new(download_size));
+    progress_bar.set_message(canvas_file.display_name.to_string());
+    progress_bar.set_style(options.progress_style.clone());
+
+    // Download
+    while let Some(chunk) = resp.chunk().await? {
+        progress_bar.inc(chunk.len() as u64);
+        let mut cursor = std::io::Cursor::new(chunk);
+        std::io::copy(&mut cursor, &mut file)
+            .unwrap_or_else(|e| panic!("Could not save file {:?}, err={e}", canvas_file.filepath));
+    }
+
+    progress_bar.finish();
     Ok(())
 }
 
@@ -349,8 +312,11 @@ fn print_all_courses_by_term(courses: &[canvas::Course]) {
 }
 
 // async recursion needs boxing
-async fn process_folders(url: String, path: PathBuf, options: Arc<ProcessOptions>) {
-    let pages = get_pages(url, &options).await;
+async fn process_folders(
+    (url, path): (String, PathBuf),
+    options: Arc<ProcessOptions>,
+) -> Result<()> {
+    let pages = get_pages(url, &options).await?;
 
     // For each page
     for pg in pages {
@@ -371,24 +337,25 @@ async fn process_folders(url: String, path: PathBuf, options: Arc<ProcessOptions
                         path.clone()
                     };
                     if !folder_path.exists() {
-                        std::fs::create_dir(&folder_path).unwrap_or_else(|e| {
-                            panic!(
+                        if let Err(e) = std::fs::create_dir(&folder_path) {
+                            eprintln!(
                                 "Failed to create directory: {}, err={e}",
                                 folder_path.to_string_lossy()
-                            )
-                        });
+                            );
+                            continue;
+                        };
                     }
 
                     fork!(
                         process_files,
-                        folder.files_url,
-                        folder_path.clone(),
+                        (folder.files_url, folder_path.clone()),
+                        (String, PathBuf),
                         options.clone()
                     );
                     fork!(
                         process_folders,
-                        folder.folders_url,
-                        folder_path,
+                        (folder.folders_url, folder_path),
+                        (String, PathBuf),
                         options.clone()
                     );
                 }
@@ -398,7 +365,7 @@ async fn process_folders(url: String, path: PathBuf, options: Arc<ProcessOptions
             Ok(canvas::FolderResult::Err { status }) => {
                 let course_has_no_folders = status == "unauthorized";
                 if !course_has_no_folders {
-                    println!(
+                    eprintln!(
                         "Failed to access folders at link:{uri}, path:{path:?}, status:{status}",
                     );
                 }
@@ -406,14 +373,16 @@ async fn process_folders(url: String, path: PathBuf, options: Arc<ProcessOptions
 
             // Parse error
             Err(e) => {
-                println!("Failed to deserialize folders at link:{uri}, path:{path:?}\n{e:?}",);
+                eprintln!("Failed to deserialize folders at link:{uri}, path:{path:?}\n{e:?}",);
             }
         }
     }
+
+    Ok(())
 }
 
-async fn process_files(url: String, path: PathBuf, options: Arc<ProcessOptions>) {
-    let pages = get_pages(url, &options).await;
+async fn process_files((url, path): (String, PathBuf), options: Arc<ProcessOptions>) -> Result<()> {
+    let pages = get_pages(url, &options).await?;
 
     // For each page
     for pg in pages {
@@ -432,7 +401,7 @@ async fn process_files(url: String, path: PathBuf, options: Arc<ProcessOptions>)
             Ok(canvas::FileResult::Err { status }) => {
                 let course_has_no_files = status == "unauthorized";
                 if !course_has_no_files {
-                    println!(
+                    eprintln!(
                         "Failed to access files at link:{uri}, path:{path:?}, status:{status}",
                     );
                 }
@@ -440,10 +409,12 @@ async fn process_files(url: String, path: PathBuf, options: Arc<ProcessOptions>)
 
             // Parse error
             Err(e) => {
-                println!("Failed to deserialize files at link:{uri}, path:{path:?}\n{e:?}",);
+                eprintln!("Failed to deserialize files at link:{uri}, path:{path:?}\n{e:?}",);
             }
         };
     }
+
+    Ok(())
 }
 
 fn filter_files(options: &ProcessOptions, path: &Path, files: Vec<File>) -> Vec<File> {
@@ -471,12 +442,22 @@ fn filter_files(options: &ProcessOptions, path: &Path, files: Vec<File>) -> Vec<
         })
         .filter(|f| !f.locked_for_user)
         .filter(|f| {
+            if DateTime::parse_from_rfc3339(&f.updated_at).is_ok() {
+                return true;
+            }
+            eprintln!(
+                "Failed to parse updated_at time for {}, {}",
+                f.display_name, f.updated_at
+            );
+            false
+        })
+        .filter(|f| {
             !f.filepath.exists() || (updated(&f.filepath, &f.updated_at) && options.download_newer)
         })
         .collect()
 }
 
-async fn get_pages(link: String, options: &ProcessOptions) -> Vec<Response> {
+async fn get_pages(link: String, options: &ProcessOptions) -> Result<Vec<Response>> {
     fn parse_next_page(resp: &Response) -> Option<String> {
         // Parse LINK header
         let links = resp.headers().get(header::LINK)?.to_str().ok()?; // ok to not have LINK header
@@ -513,15 +494,14 @@ async fn get_pages(link: String, options: &ProcessOptions) -> Vec<Response> {
             .get(&uri)
             .bearer_auth(&options.canvas_token)
             .send()
-            .await
-            .unwrap_or_else(|e| panic!("Something went wrong when reaching {}, err={e}", uri));
+            .await?; // TODO add timeout + retry logic
 
         // Get next page before returning for json
         link = parse_next_page(&resp);
         resps.push(resp);
     }
 
-    resps
+    Ok(resps)
 }
 
 mod canvas {
@@ -584,12 +564,14 @@ mod canvas {
     }
 
     pub struct ProcessOptions {
-        // Input parameters
         pub canvas_token: String,
         pub client: reqwest::Client,
+        // Process
         pub download_newer: bool,
-        // Output
         pub files_to_download: Mutex<Vec<File>>,
+        // Download
+        pub progress_bars: indicatif::MultiProgress,
+        pub progress_style: indicatif::ProgressStyle,
         // Synchronization
         pub n_active_requests: AtomicUsize, // main() waits for this to be 0
         pub sem_requests: tokio::sync::Semaphore, // Limit #active requests

--- a/src/main.rs
+++ b/src/main.rs
@@ -275,7 +275,7 @@ async fn download_file(
     // Get file
     let mut resp = options
         .client
-        .head(&canvas_file.url)
+        .get(&canvas_file.url)
         .bearer_auth(&options.canvas_token)
         .send()
         .await

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,7 @@ macro_rules! fork {
                     options.notify_main.notify_one();
                 }
                 if let Err(e) = res {
-                    eprintln!("{e:#?}");
+                    eprintln!("{e:?}");
                 }
             });
         }
@@ -243,7 +243,7 @@ async fn atomic_download_file(file: File, options: Arc<ProcessOptions>) -> Resul
     if let Err(e) = download_file((&tmp_path, &file), options.clone()).await {
         if let Err(e) = std::fs::remove_file(&tmp_path) {
             eprintln!(
-                "Failed to remove temporary file {tmp_path:?} for {}, err={e:#?}",
+                "Failed to remove temporary file {tmp_path:?} for {}, err={e:?}",
                 file.display_name
             );
         }
@@ -258,7 +258,7 @@ async fn atomic_download_file(file: File, options: Arc<ProcessOptions>) -> Resul
     );
     if let Err(e) = filetime::set_file_mtime(&tmp_path, updated_time) {
         eprintln!(
-            "Failed to set modified time of {} with updated_at of {}, err={e:#?}",
+            "Failed to set modified time of {} with updated_at of {}, err={e:?}",
             file.display_name, file.updated_at
         )
     }
@@ -282,7 +282,7 @@ async fn download_file(
         .with_context(|| format!("Something went wrong when reaching {}", canvas_file.url))?;
     if !resp.status().is_success() {
         return Err(Error::msg(format!(
-            "Failed to download {}, got {resp:#?}",
+            "Failed to download {}, got {resp:?}",
             canvas_file.display_name
         )));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,7 +124,7 @@ async fn main() -> Result<()> {
         .map(serde_json::from_value) // json --> Result<course>
         .try_collect()
         .await
-        .with_context(|| "Failed to deserialize course json")?; // Result<course> --> course
+        .with_context(|| "Error when getting course json")?; // Result<course> --> course
 
     // Filter courses by term IDs
     let Some(term_ids) = args.term_ids else {
@@ -392,7 +392,7 @@ async fn process_folders(
 
             // Parse error
             Err(e) => {
-                eprintln!("Failed to deserialize folders at link:{uri}, path:{path:?}\n{e:?}",);
+                eprintln!("Error when getting folders at link:{uri}, path:{path:?}\n{e:?}",);
             }
         }
     }
@@ -428,7 +428,7 @@ async fn process_files((url, path): (String, PathBuf), options: Arc<ProcessOptio
 
             // Parse error
             Err(e) => {
-                eprintln!("Failed to deserialize files at link:{uri}, path:{path:?}\n{e:?}",);
+                eprintln!("Error when getting files at link:{uri}, path:{path:?}\n{e:?}",);
             }
         };
     }
@@ -512,8 +512,9 @@ async fn get_pages(link: String, options: &ProcessOptions) -> Result<Vec<Respons
             .client
             .get(&uri)
             .bearer_auth(&options.canvas_token)
+            .timeout(Duration::from_secs(10))
             .send()
-            .await?; // TODO add timeout + retry logic
+            .await?;
 
         // Get next page before returning for json
         link = parse_next_page(&resp);


### PR DESCRIPTION
### Problem
File download may fail for any number of reasons. Because the file now exists (in a possibly corrupted state), it will not be overwritten in subsequent runs.

### Solution
We solve this by downloading to a temporary file in the same directory, then renaming it to the actual file name or deleting it upon failure. Renaming should be atomic in POSIX systems for the same directory.

### Implementation
Some additional fixes were added in this rewrite
- Refactor file download to `async fn(tmp_path, real_path, ...) -> Result`
- Using the `Result`, we can rename if `Ok` or delete `tmp_path` if `Err` + `eprintln!()` the error
- Use `fork!()` macro to download files with higher concurrency
- Timeout for getting of course/folder/file metadata only, because file downloads may be huge and we can't bound download time
- Change `unwrap` panics into returned `Err`, since panicking threads are messy to handle

Fixes #29